### PR TITLE
failed to install lxc-docker

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: install docker
   apt:
-    name: "lxc-docker={{ version }}"
+    name: "lxc-docker-{{ version }}"
 
 - name: ensure docker is running
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,12 @@
 ---
-- name: docker.io apt key
-  apt_key:
-    id: "{{ apt_key_sig }}"
-    url: "{{ apt_key_url }}"
-    state: present
+# - name: docker.io apt key
+#   apt_key:
+#     id: "{{ apt_key_sig }}"
+#     #url: "{{ apt_key_url }}"
+#     keyserver: http://keyserver.ubuntu.com/
+#     state: present
 
+- shell: "curl -sSL {{ apt_key_url }} | gpg --import"
 - name: docker.io repository
   apt_repository:
     repo: "{{ apt_repository }}"
@@ -23,6 +25,7 @@
 - name: install docker
   apt:
     name: "lxc-docker-{{ version }}"
+    force: yes
 
 - name: ensure docker is running
   service:


### PR DESCRIPTION
`
TASK [gorsuch.docker : install docker] ****************************************************************************************************************
fatal: [vagrant]: FAILED! => {"cache_update_time": 1508158000, "cache_updated": false, "changed": false, "failed": true, "msg": "'/usr/bin/apt-get -y -
o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'lxc-docker=0.11.1'' failed: E: Version '0.11.1' for 'lxc-dock
er' was not found\n", "rc": 100, "stderr": "E: Version '0.11.1' for 'lxc-docker' was not found\n", "stderr_lines": ["E: Version '0.11.1' for 'lxc-docke
r' was not found"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\n", "stdout_lines": ["Reading packag
e lists...", "Building dependency tree...", "Reading state information..."]}
`

the version could be selected using lxc-docker-{{ version }}:

 `
/vagrant$ aptitude search lxc-docker                                               
p   lxc-docker                                                          - Linux container runtime
p   lxc-docker-0.10.0                                                   - Linux container runtime                                                
p   lxc-docker-0.11.0                                                   - Linux container runtime                                                  
p   lxc-docker-0.11.1                                                   - Linux container runtime
p   lxc-docker-0.12.0                                                   - Linux container runtime
p   lxc-docker-0.5.3                                                    - lxc-docker is a Linux container runtime
p   lxc-docker-0.6.0                                                    - lxc-docker is a Linux container runtime
....
`