### PR TITLE
Update version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: docker
   license: MIT
   min_ansible_version: 1.4
-  version: 0.1.0
+  version: 0.1.1
 
   platforms:
     - name: Ubuntu


### PR DESCRIPTION
@gorsuch I've been trying to get the role with ansible-galaxy, but I'm still getting the old version. Maybe updating the role version allows me to get the last changes.

What do you think?

Here is the page at [galaxy](https://galaxy.ansible.com/gorsuch/docker/).